### PR TITLE
FIX issues with FBX files exported by 3ds Max 2021

### DIFF
--- a/Modules/AssetPipelineEditor/AssetPostprocessors/FBXMaterialDescriptionPreprocessor.cs
+++ b/Modules/AssetPipelineEditor/AssetPostprocessors/FBXMaterialDescriptionPreprocessor.cs
@@ -43,9 +43,11 @@ namespace UnityEditor.Experimental.AssetImporters
         {
             float classIdA;
             float classIdB;
+            string orgMtl;
             description.TryGetProperty("ClassIDa", out classIdA);
             description.TryGetProperty("ClassIDb", out classIdB);
-            return classIdA == 1030429932 && classIdB == -559038463;
+            description.TryGetProperty("ORIGINAL_MTL", out orgMtl);
+            return (classIdA == 1030429932 && classIdB == -559038463) || ((classIdA == 2121471519 && classIdB == 1660373836) && (orgMtl == "PHYSICAL_MTL"));
         }
 
         static bool IsMayaArnoldStandardSurfaceMaterial(MaterialDescription description)
@@ -59,9 +61,11 @@ namespace UnityEditor.Experimental.AssetImporters
         {
             float classIdA;
             float classIdB;
+            string orgMtl;
             description.TryGetProperty("ClassIDa", out classIdA);
             description.TryGetProperty("ClassIDb", out classIdB);
-            return classIdA == 2121471519 && classIdB == 1660373836;
+            description.TryGetProperty("ORIGINAL_MTL", out orgMtl);
+            return (classIdA == 2121471519 && classIdB == 1660373836) && (orgMtl != "PHYSICAL_MTL");
         }
 
         static bool IsAutodeskInteractiveMaterial(MaterialDescription description)


### PR DESCRIPTION
3ds Max 2021 introduced an undocumented change when exporting physical materials to FBX.
Which leaves the MaterialDescription based import unable to decide if it is a physical or Arnold material.

Basicly 3ds Max 2021 writes out the Arnod Standard Surface material ClassId instead of the one for Physical Materials.
It also adds a new ORIGINAL_MTL property which hints to the physical material.
Sadly in that case instead of writing Arnold related properties. Physical Material properties are written making 

FBXMaterialDescriptionPreprocessor assuming it is an Arnold Standard Surface Material unable to read out any specialized properties.

The following pull request works around this change.

Autodesk is currently investigating this issue but there is no info on if or when a fix will be released.